### PR TITLE
Card effects

### DIFF
--- a/src/game/gameTypes.ts
+++ b/src/game/gameTypes.ts
@@ -5,7 +5,7 @@ export interface GameState {
   secret: SecretInfo;
   playingField: Theater[];
   selectedCardID: number;
-  ongoingEffects: string[];
+  ongoingEffects: Record<string, TheaterType>;
   playOrder: string[]; //['0', '1'], needed for turn order change
 }
 export interface Player {
@@ -14,7 +14,7 @@ export interface Player {
   firstPlayer: boolean;
   score: number;
   cards: Card[];
-  ongoingEffects: string[];
+  ongoingEffects: Record<string, TheaterType>;
 }
 export interface Theater {
   theater: TheaterType;

--- a/src/game/gameUtil.ts
+++ b/src/game/gameUtil.ts
@@ -1,4 +1,3 @@
-import { Ctx } from 'boardgame.io';
 import { cardInfoRecords } from './cardInfo';
 import { Card, TheaterType } from './cards';
 import { GameState } from './gameTypes';
@@ -47,19 +46,28 @@ export function getPointsScored(
   }
   return points;
 }
-export function Flip(G: GameState, ctx: Ctx): void {
-  // flip() {
-  //   if (!this.covered) {
-  //     if (this.faceDown) {
-  //       this.strength = this.cardInfo.strength;
-  //       this.faceDown = false;
-  //     } else {
-  //       this.strength = 2;
-  //       this.faceDown = true;
-  //     }
-  //   }
-  // },
-  // effect: (G, ctx) => {},
+//Toggle
+export function Flip(
+  G: GameState,
+  cardIndex: number,
+  theaterID: number,
+  deployedSideID: string,
+): void {
+  var cards = G.playingField[theaterID].deployedCards[deployedSideID];
+  cards[cardIndex].faceDown = !cards[cardIndex].faceDown;
+
+  //if card face down, remove from ongoing effects Records
+  if (cards[cardIndex].faceDown) {
+    delete G.ongoingEffects[cards[cardIndex].cardID];
+    delete G.players['0'].ongoingEffects[cards[cardIndex].cardID];
+    delete G.players['1'].ongoingEffects[cards[cardIndex].cardID];
+  }
+  //if card now face up, do card effect (I think this always happens? gotta read the rules again)
+  if (!cards[cardIndex].faceDown) {
+    CardEffect(G, deployedSideID, cards[cardIndex].cardID, theaterID);
+  }
+
+  RecalculateTotalStrength(G, deployedSideID);
 }
 export function CardEffect(
   G: GameState,
@@ -72,23 +80,29 @@ export function CardEffect(
     cardInfoRecords[cardID].type == 'ongoing' &&
     cardInfoRecords[cardID].ongoingType == 'player'
   ) {
-    G.players[playerID].ongoingEffects.push(cardID);
+    G.players[playerID].ongoingEffects[cardID] =
+      G.playingField[theaterID].theater;
   } else if (
     cardInfoRecords[cardID].type == 'ongoing' &&
     cardInfoRecords[cardID].ongoingType == 'global'
   ) {
-    G.ongoingEffects.push(cardID);
+    G.ongoingEffects[cardID] = G.playingField[theaterID].theater;
   }
+
+  //if(cardInfoRecords[cardID].name == 'Maneuver'){
+  // let adjacents = GetAdjacentTheaters(G, theaterID);
+
+  //}
   switch (cardID) {
     case 'Support':
       break;
     case 'Air_Drop':
-      G.players[playerID].ongoingEffects.push(cardID);
+      G.players[playerID].ongoingEffects[cardID] =
+        G.playingField[theaterID].theater;
       break;
     case 'Maneuver_Air':
       break;
     case 'Aerodrome':
-      //G.players[playerID].ongoingEffects.push(cardID);
       break;
     case 'Containment':
       break;
@@ -101,7 +115,6 @@ export function CardEffect(
     case 'Maneuver_Land':
       break;
     case 'Cover_Fire':
-      //G.players[playerID].ongoingEffects.push(cardID);
       break;
     case 'Disrupt':
       break;
@@ -110,7 +123,6 @@ export function CardEffect(
     case 'Transport':
       break;
     case 'Escalation':
-      //G.players[playerID].ongoingEffects.push(cardID);
       break;
     case 'Maneuver_Sea':
       break;
@@ -131,10 +143,10 @@ export function SetValidTheaters(
 ): void {
   let validTheater = card.cardInfo.theater;
   G.playingField.map((theater) => {
-    if (G.players[playerID].ongoingEffects.includes('Air_Drop')) {
+    if ('Air_Drop' in G.players[playerID].ongoingEffects) {
       theater.isValid = true;
     } else if (
-      G.players[playerID].ongoingEffects.includes('Aerodrome') &&
+      'Aerodrome' in G.players[playerID].ongoingEffects &&
       card.strength <= 3
     ) {
       theater.isValid = true;
@@ -144,39 +156,73 @@ export function SetValidTheaters(
   });
 
   //on the turn after Air Drop is played, this effect should go away
-  if (G.players[playerID].ongoingEffects.includes('Air_Drop')) {
-    G.players[playerID].ongoingEffects.splice(
-      G.ongoingEffects.indexOf('Air_Drop'),
-      1,
-    );
-  }
+  delete G.players[playerID].ongoingEffects['Air_Drop'];
 }
 export function CalculateCardStrength(
   G: GameState,
   playerID: string,
   card: Card,
+  theaterID: number,
 ): number {
-  if (
-    card.faceDown &&
-    G.players[playerID].ongoingEffects.includes('Escalation')
-  )
+  //Escalation: all your facedown cards are now strength 4
+  if (card.faceDown && 'Escalation' in G.players[playerID].ongoingEffects)
     return 4;
-  else if (card.faceDown) return 2;
+  //Cover Fire: all cards covered by this card are now strength 4
+  else if (
+    'Cover_Fire' in G.players[playerID].ongoingEffects &&
+    G.playingField[theaterID].theater ==
+      G.players[playerID].ongoingEffects['Cover_Fire']
+  ) {
+    var coverFireCard = G.playingField[theaterID].deployedCards[playerID].find(
+      (card) => card.cardID == 'Cover_Fire',
+    );
+    if (
+      G.playingField[theaterID].deployedCards[playerID].indexOf(card) <
+      G.playingField[theaterID].deployedCards[playerID].indexOf(coverFireCard!)
+    ) {
+      return 4;
+    }
+  }
+  if (card.faceDown) return 2;
   else return card.cardInfo.strength;
 }
 
 //recalculate card strength and total strength for player
-export function RecalculateTotalStrength(
-  G: GameState,
-  playerID: string,
-  card: Card,
-): void {
+export function RecalculateTotalStrength(G: GameState, playerID: string): void {
+  //support gives +3 strength to your adjacent theaters
+  var adjacents;
+  if ('Support' in G.players[playerID].ongoingEffects) {
+    adjacents = GetAdjacentTheatersByName(
+      G,
+      G.players[playerID].ongoingEffects['Support'],
+    );
+  }
   for (let theater of G.playingField) {
-    theater.totalStrength[playerID] = 0;
+    if (adjacents && adjacents.includes(theater.theater))
+      theater.totalStrength[playerID] = 3;
+    else theater.totalStrength[playerID] = 0;
     for (let card of theater.deployedCards[playerID]) {
-      card.strength = CalculateCardStrength(G, playerID, card);
+      card.strength = CalculateCardStrength(
+        G,
+        playerID,
+        card,
+        G.playingField.indexOf(
+          G.playingField.find((t) => t.theater == theater.theater)!,
+        ),
+      );
       theater.totalStrength[playerID] += card.strength;
     }
+  }
+}
+
+export function GetAdjacentTheatersByName(
+  G: GameState,
+  theaterName: TheaterType,
+): TheaterType[] {
+  if (G.playingField[1].theater == theaterName) {
+    return [G.playingField[0].theater, G.playingField[2].theater];
+  } else {
+    return [G.playingField[1].theater];
   }
 }
 export function GetAdjacentTheaters(

--- a/src/game/gameUtil.ts
+++ b/src/game/gameUtil.ts
@@ -1,4 +1,5 @@
 import { Ctx } from 'boardgame.io';
+import { cardInfoRecords } from './cardInfo';
 import { Card, TheaterType } from './cards';
 import { GameState } from './gameTypes';
 
@@ -67,6 +68,17 @@ export function CardEffect(
   theaterID: number,
 ): void {
   //const theater = G.playingField[theaterID].theater;
+  if (
+    cardInfoRecords[cardID].type == 'ongoing' &&
+    cardInfoRecords[cardID].ongoingType == 'player'
+  ) {
+    G.players[playerID].ongoingEffects.push(cardID);
+  } else if (
+    cardInfoRecords[cardID].type == 'ongoing' &&
+    cardInfoRecords[cardID].ongoingType == 'global'
+  ) {
+    G.ongoingEffects.push(cardID);
+  }
   switch (cardID) {
     case 'Support':
       break;
@@ -76,7 +88,7 @@ export function CardEffect(
     case 'Maneuver_Air':
       break;
     case 'Aerodrome':
-      G.players[playerID].ongoingEffects.push(cardID);
+      //G.players[playerID].ongoingEffects.push(cardID);
       break;
     case 'Containment':
       break;
@@ -89,6 +101,7 @@ export function CardEffect(
     case 'Maneuver_Land':
       break;
     case 'Cover_Fire':
+      //G.players[playerID].ongoingEffects.push(cardID);
       break;
     case 'Disrupt':
       break;
@@ -97,7 +110,7 @@ export function CardEffect(
     case 'Transport':
       break;
     case 'Escalation':
-      G.players[playerID].ongoingEffects.push(cardID);
+      //G.players[playerID].ongoingEffects.push(cardID);
       break;
     case 'Maneuver_Sea':
       break;
@@ -149,7 +162,7 @@ export function CalculateCardStrength(
   )
     return 4;
   else if (card.faceDown) return 2;
-  else return card.strength;
+  else return card.cardInfo.strength;
 }
 
 //recalculate card strength and total strength for player

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -13,7 +13,7 @@ export const AirLandSea: Game<GameState> = {
   setup: () => ({
     secret: { deck: battleCards, discardPile: [] },
     selectedCardID: -1,
-    ongoingEffects: [],
+    ongoingEffects: {},
     playOrder: ['0', '1'],
     players: {
       '0': {
@@ -22,7 +22,7 @@ export const AirLandSea: Game<GameState> = {
         cards: [],
         ready: false,
         score: 0,
-        ongoingEffects: [],
+        ongoingEffects: {},
       },
       '1': {
         ID: '1',
@@ -30,7 +30,7 @@ export const AirLandSea: Game<GameState> = {
         cards: [],
         ready: false,
         score: 0,
-        ongoingEffects: [],
+        ongoingEffects: {},
       },
     },
     playingField: [
@@ -74,12 +74,8 @@ export const AirLandSea: Game<GameState> = {
         stages: {
           select: { moves: { selectCard, withdraw } },
           place: { moves: { deploy, improvise } },
+          //cardEffect: { moves: {} }, //guessing this'll be needed for instant effects
         },
-      },
-    },
-    epicWinningAnimation: {
-      onBegin: ({ G, ctx }) => {
-        //something crazy idk
       },
     },
   },

--- a/src/game/moves.ts
+++ b/src/game/moves.ts
@@ -24,36 +24,46 @@ export const improvise: Move<GameState> = (
   { G, ctx, events, playerID },
   theaterID: number,
 ) => {
-  //TODO: if blockade, immediately discard card
-  G.players[playerID].cards[G.selectedCardID].faceDown = true;
-  let arrLength = G.playingField[theaterID].deployedCards[
-    ctx.currentPlayer
-  ].push(...G.players[playerID].cards.splice(G.selectedCardID, 1));
+  //if blockade in play and total cards in theater >= 3 immediately discard card
+  if (
+    G.ongoingEffects.includes('Blockade') &&
+    G.playingField[theaterID].deployedCards['0'].length +
+      G.playingField[theaterID].deployedCards['1'].length >=
+      3
+  ) {
+    G.secret.discardPile.push(
+      ...G.players[playerID].cards.splice(G.selectedCardID, 1),
+    );
+  } else {
+    G.players[playerID].cards[G.selectedCardID].faceDown = true;
+    let arrLength = G.playingField[theaterID].deployedCards[
+      ctx.currentPlayer
+    ].push(...G.players[playerID].cards.splice(G.selectedCardID, 1));
 
-  //set previous uncovered card to covered
-  const coveredCard =
-    G.playingField[theaterID].deployedCards[ctx.currentPlayer].at(-2);
-  if (coveredCard !== undefined) {
-    G.playingField[theaterID].deployedCards[ctx.currentPlayer][
-      arrLength - 2
-    ].covered = true;
-  }
+    //set previous uncovered card to covered
+    const coveredCard =
+      G.playingField[theaterID].deployedCards[ctx.currentPlayer].at(-2);
+    if (coveredCard !== undefined) {
+      G.playingField[theaterID].deployedCards[ctx.currentPlayer][
+        arrLength - 2
+      ].covered = true;
+    }
 
-  //set card strength
-  G.playingField[theaterID].deployedCards[ctx.currentPlayer][
-    arrLength - 1
-  ].strength = CalculateCardStrength(
-    G,
-    playerID,
-    G.playingField[theaterID].deployedCards[ctx.currentPlayer][arrLength - 1],
-  );
-
-  //update total strength for theater
-  G.playingField[theaterID].totalStrength[ctx.currentPlayer] +=
+    //set card strength
     G.playingField[theaterID].deployedCards[ctx.currentPlayer][
       arrLength - 1
-    ].strength;
+    ].strength = CalculateCardStrength(
+      G,
+      playerID,
+      G.playingField[theaterID].deployedCards[ctx.currentPlayer][arrLength - 1],
+    );
 
+    //update total strength for theater
+    G.playingField[theaterID].totalStrength[ctx.currentPlayer] +=
+      G.playingField[theaterID].deployedCards[ctx.currentPlayer][
+        arrLength - 1
+      ].strength;
+  }
   events.endTurn();
 };
 

--- a/src/game/moves.ts
+++ b/src/game/moves.ts
@@ -1,17 +1,18 @@
 import { Move } from 'boardgame.io';
 import { GameState } from './gameTypes';
 import {
-  CalculateCardStrength,
   CardEffect,
+  GetAdjacentTheaters,
   getPointsScored,
+  RecalculateTotalStrength,
   SetValidTheaters,
 } from './gameUtil';
 
 export const selectCard: Move<GameState> = (
   { G, ctx, events, playerID },
-  cardID: number,
+  cardIndex: number,
 ) => {
-  G.selectedCardID = cardID;
+  G.selectedCardID = cardIndex;
   SetValidTheaters(
     G,
     playerID,
@@ -24,45 +25,35 @@ export const improvise: Move<GameState> = (
   { G, ctx, events, playerID },
   theaterID: number,
 ) => {
-  //if blockade in play and total cards in theater >= 3 immediately discard card
+  //if blockade in play and total cards in adj theater >= 3 immediately discard card
+  //or if containment in play, discard card
   if (
-    G.ongoingEffects.includes('Blockade') &&
-    G.playingField[theaterID].deployedCards['0'].length +
-      G.playingField[theaterID].deployedCards['1'].length >=
-      3
+    ('Blockade' in G.ongoingEffects &&
+      GetAdjacentTheaters(G, theaterID).includes(
+        G.ongoingEffects['Blockade'],
+      ) &&
+      G.playingField[theaterID].deployedCards['0'].length +
+        G.playingField[theaterID].deployedCards['1'].length >=
+        3) ||
+    'Containment' in G.ongoingEffects
   ) {
     G.secret.discardPile.push(
       ...G.players[playerID].cards.splice(G.selectedCardID, 1),
     );
   } else {
     G.players[playerID].cards[G.selectedCardID].faceDown = true;
-    let arrLength = G.playingField[theaterID].deployedCards[
-      ctx.currentPlayer
-    ].push(...G.players[playerID].cards.splice(G.selectedCardID, 1));
+    let arrLength = G.playingField[theaterID].deployedCards[playerID].push(
+      ...G.players[playerID].cards.splice(G.selectedCardID, 1),
+    );
 
     //set previous uncovered card to covered
     const coveredCard =
-      G.playingField[theaterID].deployedCards[ctx.currentPlayer].at(-2);
+      G.playingField[theaterID].deployedCards[playerID].at(-2);
     if (coveredCard !== undefined) {
-      G.playingField[theaterID].deployedCards[ctx.currentPlayer][
-        arrLength - 2
-      ].covered = true;
+      G.playingField[theaterID].deployedCards[playerID][arrLength - 2].covered =
+        true;
     }
-
-    //set card strength
-    G.playingField[theaterID].deployedCards[ctx.currentPlayer][
-      arrLength - 1
-    ].strength = CalculateCardStrength(
-      G,
-      playerID,
-      G.playingField[theaterID].deployedCards[ctx.currentPlayer][arrLength - 1],
-    );
-
-    //update total strength for theater
-    G.playingField[theaterID].totalStrength[ctx.currentPlayer] +=
-      G.playingField[theaterID].deployedCards[ctx.currentPlayer][
-        arrLength - 1
-      ].strength;
+    RecalculateTotalStrength(G, playerID);
   }
   events.endTurn();
 };
@@ -73,38 +64,38 @@ export const deploy: Move<GameState> = (
   theaterID: number,
 ) => {
   if (G.playingField[theaterID].isValid) {
-    let { cardID } = G.players[playerID].cards[G.selectedCardID];
-    G.players[playerID].cards[G.selectedCardID].faceDown = false;
-    const arrLength = G.playingField[theaterID].deployedCards[
-      ctx.currentPlayer
-    ].push(...G.players[playerID].cards.splice(G.selectedCardID, 1));
-
-    CardEffect(G, playerID, cardID, theaterID);
-
-    //set previous uncovered card to covered
-    const coveredCard =
-      G.playingField[theaterID].deployedCards[playerID].at(-2);
-    if (coveredCard !== undefined) {
-      G.playingField[theaterID].deployedCards[playerID][arrLength - 2].covered =
-        true;
-    }
-
-    //set card strength
-    G.playingField[theaterID].deployedCards[playerID][arrLength - 1].strength =
-      CalculateCardStrength(
-        G,
-        playerID,
-        G.playingField[theaterID].deployedCards[ctx.currentPlayer][
-          arrLength - 1
-        ],
+    //if blockade in play and total cards in adj theater >= 3 immediately discard card
+    if (
+      'Blockade' in G.ongoingEffects &&
+      GetAdjacentTheaters(G, theaterID).includes(
+        G.ongoingEffects['Blockade'],
+      ) &&
+      G.playingField[theaterID].deployedCards['0'].length +
+        G.playingField[theaterID].deployedCards['1'].length >=
+        3
+    ) {
+      G.secret.discardPile.push(
+        ...G.players[playerID].cards.splice(G.selectedCardID, 1),
       );
+    } else {
+      let { cardID } = G.players[playerID].cards[G.selectedCardID];
+      G.players[playerID].cards[G.selectedCardID].faceDown = false;
+      const arrLength = G.playingField[theaterID].deployedCards[
+        ctx.currentPlayer
+      ].push(...G.players[playerID].cards.splice(G.selectedCardID, 1));
 
-    //update total strength for theater
-    G.playingField[theaterID].totalStrength[ctx.currentPlayer] +=
-      G.playingField[theaterID].deployedCards[ctx.currentPlayer][
-        arrLength - 1
-      ].strength;
+      CardEffect(G, playerID, cardID, theaterID);
 
+      //set previous uncovered card to covered
+      const coveredCard =
+        G.playingField[theaterID].deployedCards[playerID].at(-2);
+      if (coveredCard !== undefined) {
+        G.playingField[theaterID].deployedCards[playerID][
+          arrLength - 2
+        ].covered = true;
+      }
+      RecalculateTotalStrength(G, playerID);
+    }
     events.endTurn();
   } else {
     //keep letting them try til they click the right theater


### PR DESCRIPTION
All the ongoing type cards should work now.
The stuff that could be better has to do with theaters, since I sometimes need the index and sometimes the name, so I've got 2 separate functions for finding adjacent theaters (not sure if I can overload either), and getting the index from the name I had to do something dumb like
```
G.playingField.indexOf(
          G.playingField.find((t) => t.theater == theater.theater)!,
        ),
``` 
I guess it needs to be an array because it needs to be shuffled and have an order, but there's probably a better way to do this stuff

Also haven't tested the flip function I added yet, hope it works